### PR TITLE
vendor: allow modern versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ home-page = "https://github.com/ns-iknox/tap-s3-parquet"
 license = "BSD-3-Clause"
 description-file = "README.md"
 requires = [
-    "awswrangler==1.4.0",
-    "black==19.3b0",
+    "awswrangler>=1.4.0",
+    "black>=22.6.0",
     "Click>=7.0",
-    "genson==1.2.1",
-    "s3path==0.1.101",
-    "singer-python==5.9.0"
+    "genson>=1.2.1",
+    "s3path>=0.1.101",
+    "singer-python>=5.9.0"
 ]
 requires-python = ">=3.6,<4"
 classifiers = ["License :: OSI Approved :: BSD License"]


### PR DESCRIPTION
Had issues installing this in Python 3.9. This seems to work fine.